### PR TITLE
Make moment a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-mocha-test": "^0.12.7",
-    "mocha": "^2.2.4"
+    "mocha": "^2.2.4",
+    "moment": "^2.16.0"
   },
-  "dependencies": {
-    "moment": "^2.10.2"
+  "peerDependencies": {
+    "moment": ">=2.10.2"
   }
 }


### PR DESCRIPTION
I am in the process of moving from npm to yarn, and found that this package began breaking when I did so.  It seems that yarn does not have the exact same flattening scheme that npm used, and is installing a separate version of `moment` into `node_modules/moment-weekday-calc/node_modules/moment`.  Because of this, the functions that weekday-calc is adding on to moment are not put on the same moment that the rest of my app is `require`ing.  

I believe the fix, and the right thing to do no matter what, is to specify moment as a peer dependency of this package.  As a plugin, it should not be installing its own copy, but rather extending the copy which is already installed within the consuming application.

peerDependencies should be as loose as possible, but since moment had been specified here previously as `^2.10.2` I maintained that same minimum version.  If this plugin will work with older versions, the peer dependency should be loosened further, ideally back to `>=2.0.0`.