### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,16 +129,16 @@ require('moment-weekday-calc');
 console.log(moment().isoWeekdayCalc([2015,0,1],[2015,11,31],[1,2,3,4,5,6,7]));
 ```
 
-#Installation
+# Installation
 
-##NPM
+## NPM
 ```npm install moment-weekday-calc```
 
 ##Bower
 ```bower install moment-weekday-calc```
 
 # Syntax
-##weekdayCalc
+## weekdayCalc
 ### iso weekdays weekdayCalc
 Calculate specified weekdays for dates range excluding particular dates:  
 ```JavaScript

--- a/example/README.md
+++ b/example/README.md
@@ -1,12 +1,12 @@
 do ```npm install``` and ```bower install``` before trying these examples
 
-##example.html
+## example.html
 In-browser example, just open the file in browser
 
-##example_standalone_node.js
+## example_standalone_node.js
 do ```node example_standalone_node.js``` to run this example
 
-##example_node.js
+## example_node.js
 do ```node example_node.js``` to run this example  
 Please notice that you need to install moment to make it work:
 ```npm install momemt```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
